### PR TITLE
Improve object diff

### DIFF
--- a/lib/rspec-difftastic.rb
+++ b/lib/rspec-difftastic.rb
@@ -16,6 +16,11 @@ module RSpec
         "\n\n#{diff_string}\n"
       end
 
+      def diff_as_object(actual, expected)
+         diff_string = DIFFTASTIC_DIFFER.diff_objects(actual, expected)
+        "\n\n#{diff_string}\n"
+      end
+
     end
   end
 end

--- a/spec/rspec_difftastic_spec.rb
+++ b/spec/rspec_difftastic_spec.rb
@@ -23,4 +23,24 @@ RSpec.describe RSpec::Support::Differ do
       end
     end
   end
+
+  describe '#diff_as_object' do
+    context 'when actual and expected are the same' do
+      it 'returns an empty diff' do
+        actual = { a: 1, b: 2 }
+        expected = { a: 1, b: 2 }
+        diff = differ.diff_as_object(actual, expected)
+        expect(diff).to include('No changes.')
+      end
+    end
+
+    context 'when actual and expected are different' do
+      it 'returns the diff between the strings' do
+        actual = { a: 1, b: 2 }
+        expected = { a: 1, b: 3 }
+        diff = differ.diff_as_object(actual, expected)
+        expect(diff).to include('Expected', 'Actual')
+      end
+    end
+  end
 end


### PR DESCRIPTION
I was about to [publish my version of the same](https://github.com/Darhazer/rspec-difftastic) but had a name conflict for the gem ;)
So I have also implemented the object diff and enhanced the contain_exactly/match_array diffing which I can open as a separate PR. I'm testing it in a large codebase, but it's also early days. Diffing only strings however (having in mind that diff_as_object at the end calls [diffs_as_string](https://github.com/rspec/rspec/blob/6decbce170ab0bec88f461ae3bd75f65115fc54d/rspec-support/lib/rspec/support/differ.rb#L83) make it quite unusable for diffing large objects.

| Original  | Improved |
| ------------- | ------------- |
|  <img width="769" alt="Screenshot 2025-02-24 at 16 26 04" src="https://github.com/user-attachments/assets/153ca683-e608-4512-8979-49b98ec83275" /> |    <img width="875" alt="Screenshot 2025-02-24 at 16 26 39" src="https://github.com/user-attachments/assets/b3945f64-1cc6-4bf7-b1e4-c47cfe7c528c" /> |
|   <img width="1423" alt="Screenshot 2025-02-24 at 16 26 18" src="https://github.com/user-attachments/assets/def5362a-1495-477f-89e7-ac31e2a07af9" /> | <img width="1455" alt="Screenshot 2025-02-24 at 16 27 02" src="https://github.com/user-attachments/assets/ecdf544b-db8b-437c-adfd-43ba91b31dd1" />  |
|  <img width="1484" alt="Screenshot 2025-02-24 at 16 26 25" src="https://github.com/user-attachments/assets/2e7b6d42-d06e-4743-b040-75f2b85f4186" />  |   <img width="1484" alt="Screenshot 2025-02-24 at 16 27 09" src="https://github.com/user-attachments/assets/f3e7ddc6-3474-4b44-9f9e-453bdbc6183d" /> |